### PR TITLE
Update Settings.py

### DIFF
--- a/Settings.py
+++ b/Settings.py
@@ -5,7 +5,7 @@ logger = logging.getLogger(__name__)
 class Settings:
     """ Loads data from settings.txt into the bot """
 
-    PATH = os.path.join(os.getcwd(), "settings.txt")
+    PATH = os.path.join(os.path.dirname(os.path.abspath(__file__)), "settings.txt")
 
     def get_settings(self):
         logger.debug("Loading settings.txt file...")


### PR DESCRIPTION
Fixed an error that prevented the bot from launching when the cwd did not match the directory of settings.txt. Now the cwd is irrelevant to loading settings.txt and loading the settings should now always work.